### PR TITLE
#202 Responsive bug fix contact page

### DIFF
--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -53,9 +53,7 @@
         top: -3em;
         transform: rotate(-45deg);
     }
-    header{
-        width: 60%;
-    }
+
     header::after{
         content: url(/assets/Circle-Orange.svg);
         position: absolute;
@@ -68,7 +66,6 @@
         font-family: var(--header-font);
         font-size: 3em;
         max-width: 80%;
-        min-width: 5em;
         line-height: 95%;
     }
     h2, p{
@@ -80,7 +77,6 @@
     p{
         font-family: var(--paragraph-font);
         font-size: 1.2em;
-        min-width: 14em;
     }
 
     iframe{
@@ -93,6 +89,9 @@
 
     /* MEDIA QUERY TABLET = 500px */
     @media (min-width: 31rem) {
+        header {
+            width: 60%;
+        }
         p{
             min-width: 21em;
         }
@@ -126,6 +125,7 @@
         }
         h2{
             font-size: 4em;
+            min-width: 5em;
         }
         iframe{
             height: 95%;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes and the related issue(s).  
Please include relevant motivation and context, with a screenshot if necessary.  
Please include a link to the live site, where the change is implemented.  -->

Ik heb responsive issue van de section/header op de contact pagina opgelost.

Dit heb ik gedaan door de `min-width` van `p` en `h2` in de `header` weg te halen, en de `width: 60%` van de `header` weg te halen. In de tablet media-query (768px) heb ik de `min-width` op de `h2` weer teruggezet, om het originele design te behouden, en de `width: 60%` op de `header` ook weer in de tablet media-query (500px) toegevoegd.

De `section` is nu weer mooi responsive op alle schermen, tot aan de kleinste van 320px. 

Fixes #202

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
<!-- - [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update -->

##  How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] User test
- [ ] Accessibility test
- [ ] Performance test -->
- [x] Responsive Design test

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] The code is accessible
- [ ] The code is performant
- [x] The code is responsive
- [x] I have written meaningful commit messages
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README and/or Wiki)

## Images

**Before/After:**

<img width=150 src="https://github.com/user-attachments/assets/39b61ab1-115c-46f0-bd04-ac3dee659759">
<img width=150 src="https://github.com/user-attachments/assets/931cf90a-7630-4deb-8142-57ab8268c42c">

